### PR TITLE
Read format from setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "hadim",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "schema/*.json"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -51,6 +52,7 @@
   ],
   "jupyterlab": {
     "extension": true,
+    "schemaDir": "schema",
     "discovery": {
       "server": {
         "managers": [

--- a/schema/archive.json
+++ b/schema/archive.json
@@ -1,0 +1,15 @@
+{
+  "title": "Archive",
+  "description": "Archive handler options.",
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": ["zip", "tgz", "tar.gz","tbz", "tbz2", "tar.bz", "tar.bz2","txz", "tar.xz"],
+      "title": "Archive format",
+      "description": "Archive format for compressing folder; one of ['zip', 'tgz', 'tar.gz', 'tbz', 'tbz2', 'tar.bz', 'tar.bz2', 'txz', 'tar.xz']",
+      "default": "zip"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}


### PR DESCRIPTION
Due to the mismatch between the npm package name and the jupyterlab extension name the setting handling is a bit weird:

```ts
    settingRegistry
      .load("@hadim/jupyter-archive:archive")
```