### PR TITLE
Use a submenu if archive format is null

### DIFF
--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -12,6 +12,17 @@ from notebook.utils import url2path
 # The delay in ms at which we send the chunk of data
 # to the client.
 ARCHIVE_DOWNLOAD_FLUSH_DELAY = 100
+SUPPORTED_FORMAT = [
+    "zip",
+    "tgz",
+    "tar.gz",
+    "tbz",
+    "tbz2",
+    "tar.bz",
+    "tar.bz2",
+    "txz",
+    "tar.xz"
+]
 
 
 class ArchiveStream():
@@ -84,6 +95,9 @@ class DownloadArchiveHandler(IPythonHandler):
 
         archive_token = self.get_argument('archiveToken')
         archive_format = self.get_argument('archiveFormat', 'zip')
+        if archive_format not in SUPPORTED_FORMAT:
+            self.log.error("Unsupported format {}.".format(archive_format))
+            raise web.HTTPError(404)
 
         archive_path = os.path.join(cm.root_dir, url2path(archive_path))
 

--- a/schema/archive.json
+++ b/schema/archive.json
@@ -3,10 +3,10 @@
   "description": "Archive handler options.",
   "properties": {
     "format": {
-      "type": "string",
-      "enum": ["zip", "tgz", "tar.gz","tbz", "tbz2", "tar.bz", "tar.bz2","txz", "tar.xz"],
+      "type": ["string", "null"],
+      "enum": [null, "zip", "tgz", "tar.gz","tbz", "tbz2", "tar.bz", "tar.bz2","txz", "tar.xz"],
       "title": "Archive format",
-      "description": "Archive format for compressing folder; one of ['zip', 'tgz', 'tar.gz', 'tbz', 'tbz2', 'tar.bz', 'tar.bz2', 'txz', 'tar.xz']",
+      "description": "Archive format for compressing folder; one of [null (submenu), 'zip', 'tgz', 'tar.gz', 'tbz', 'tbz2', 'tar.bz', 'tar.bz2', 'txz', 'tar.xz']",
       "default": "zip"
     }
   },


### PR DESCRIPTION
When the default format is `null`, it will show a submenu in the context menu instead of an single entry returning an archive file.

Note: when switching from an archive format to null (or the other way around), the user needs to refresh the browser page to apply the new settings (he will be informed through a dialog). This should not be too much burden as this will probably be a one time change.

Closes #13 