### PR TITLE
[WIP] Follow symlinks and exclude hidden directories

### DIFF
--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -130,7 +130,9 @@ class DownloadArchiveHandler(IPythonHandler):
 
         with make_writer(self, archive_format) as archive:
             prefix = len(str(archive_path.parent)) + len(os.path.sep)
-            for root, _, files in os.walk(archive_path):
+            for root, dirs, files in os.walk(archive_path, followlinks=True):
+                files = [f for f in files if not f[0] == '.']
+                dirs[:] = [d for d in dirs if not d[0] == '.']
                 for file_ in files:
                     file_name = os.path.join(root, file_)
                     if not self.canceled:

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -149,8 +149,8 @@ class DownloadArchiveHandler(IPythonHandler):
                 # This ensures that if download_hidden is false, then the
                 # hidden files are skipped when walking the directory.
                 if not download_hidden:
-                files = [f for f in files if not f[0] == '.']
-                dirs[:] = [d for d in dirs if not d[0] == '.']
+                    files = [f for f in files if not f[0] == '.']
+                    dirs[:] = [d for d in dirs if not d[0] == '.']
                 for file_ in files:
                     file_name = os.path.join(root, file_)
                     if not self.canceled:

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -126,11 +126,14 @@ class DownloadArchiveHandler(IPythonHandler):
         self.flush_cb.stop()
         self.finish()
 
-    def archive_and_download(self, archive_path, archive_format, archive_token):
+    def archive_and_download(self, archive_path, archive_format, archive_token, follow_symlinks, download_hidden):
 
         with make_writer(self, archive_format) as archive:
             prefix = len(str(archive_path.parent)) + len(os.path.sep)
-            for root, dirs, files in os.walk(archive_path, followlinks=True):
+            for root, dirs, files in os.walk(archive_path, followlinks=follow_symlinks):
+                # This ensures that if download_hidden is false, then the
+                # hidden files are skipped when walking the directory.
+                if not download_hidden:
                 files = [f for f in files if not f[0] == '.']
                 dirs[:] = [d for d in dirs if not d[0] == '.']
                 for file_ in files:

--- a/jupyter_archive/tests/test_archive_handler.py
+++ b/jupyter_archive/tests/test_archive_handler.py
@@ -29,15 +29,48 @@ class ArchiveHandlerTest(NotebookTestBase):
             f.write("hello2")
         with open(pjoin(archive_dir_path, "test3.md"), "w") as f:
             f.write("hello3")
+        with open(pjoin(archive_dir_path, ".test4.md"), "w") as f:
+            f.write("hello4")
+        os.makedirs(pjoin(archive_dir_path, ".test-hidden-folder"))
+        with open(pjoin(archive_dir_path, ".test-hidden-folder", "test5.md"), "w") as f:
+            f.write("hello5")
+        symlink_dir_path = pjoin(nbdir, "symlink-archive-dir")
+        os.makedirs(symlink_dir_path)
+        with open(pjoin(symlink_dir_path, "test6.md"), "w") as f:
+            f.write("hello6")
+        os.symlink(symlink_dir_path, pjoin(archive_dir_path, "symlink-test-dir"))
 
         # Try to download the created folder.
         archive_relative_path = os.path.basename(archive_dir_path)
-        url_template = "directories/{}?archiveToken=564646&archiveFormat={}"
+        url_template = "directories/{}?archiveToken=564646&archiveFormat={}&followSymlinks={}&downloadHidden={}"
 
         file_lists = {
-            "download-archive-dir/test2.txt",
-            "download-archive-dir/test1.txt",
-            "download-archive-dir/test3.md",
+            "falsefalse": {
+                "download-archive-dir/test2.txt",
+                "download-archive-dir/test1.txt",
+                "download-archive-dir/test3.md",
+            },
+            "falsetrue": {
+                "download-archive-dir/test2.txt",
+                "download-archive-dir/test1.txt",
+                "download-archive-dir/test3.md",
+                "download-archive-dir/.test4.md",
+                "download-archive-dir/.test-hidden-folder/test5.md",
+            },
+            "truefalse": {
+                "download-archive-dir/test2.txt",
+                "download-archive-dir/test1.txt",
+                "download-archive-dir/test3.md",
+                "download-archive-dir/symlink-test-dir/test6.md"
+            },
+            "truetrue": {
+                "download-archive-dir/test2.txt",
+                "download-archive-dir/test1.txt",
+                "download-archive-dir/test3.md",
+                "download-archive-dir/.test4.md",
+                "download-archive-dir/.test-hidden-folder/test5.md",
+                "download-archive-dir/symlink-test-dir/test7.md"
+            }
         }
 
         format_mode = {
@@ -52,18 +85,21 @@ class ArchiveHandlerTest(NotebookTestBase):
             "tar.xz": "r|xz",
         }
 
-        for format, mode in format_mode.items():
-            url = url_template.format(archive_relative_path, format)
-            r = self.request("GET", url)
-            assert r.status_code == 200
-            assert r.headers["content-type"] == "application/octet-stream"
-            assert r.headers["cache-control"] == "no-cache"
-            if format == "zip":
-                with zipfile.ZipFile(io.BytesIO(r.content), mode=mode) as zf:
-                    assert set(zf.namelist()) == file_lists
-            else:
-                with tarfile.open(fileobj=io.BytesIO(r.content), mode=mode) as tf:
-                    assert set(map(lambda m: m.name, tf.getmembers())) == file_lists
+        for followSymlinks in ["true", "false"]:
+            for download_hidden in ["true", "false"]:
+                file_list = file_lists[followSymlinks + download_hidden]
+                for format, mode in format_mode.items():
+                    url = url_template.format(archive_relative_path, format, followSymlinks, download_hidden)
+                    r = self.request("GET", url)
+                    assert r.status_code == 200
+                    assert r.headers["content-type"] == "application/octet-stream"
+                    assert r.headers["cache-control"] == "no-cache"
+                    if format == "zip":
+                        with zipfile.ZipFile(io.BytesIO(r.content), mode=mode) as zf:
+                            assert set(zf.namelist()) == file_list
+                    else:
+                        with tarfile.open(fileobj=io.BytesIO(r.content), mode=mode) as tf:
+                            assert set(map(lambda m: m.name, tf.getmembers())) == file_list
 
     def test_extract(self):
 

--- a/jupyter_archive/tests/test_archive_handler.py
+++ b/jupyter_archive/tests/test_archive_handler.py
@@ -69,7 +69,7 @@ class ArchiveHandlerTest(NotebookTestBase):
                 "download-archive-dir/test3.md",
                 "download-archive-dir/.test4.md",
                 "download-archive-dir/.test-hidden-folder/test5.md",
-                "download-archive-dir/symlink-test-dir/test7.md"
+                "download-archive-dir/symlink-test-dir/test6.md"
             }
         }
 

--- a/schema/archive.json
+++ b/schema/archive.json
@@ -8,6 +8,20 @@
       "title": "Archive format",
       "description": "Archive format for compressing folder; one of [null (submenu), 'zip', 'tgz', 'tar.gz', 'tbz', 'tbz2', 'tar.bz', 'tar.bz2', 'txz', 'tar.xz']",
       "default": "zip"
+    },
+    "followSymlinks": {
+      "type": ["string"],
+      "enum": ["true", "false"],
+      "title": "Follow Symlinks",
+      "description": "Whether or not to resolve symlinks and add resulting files to the archive; one of ['true', 'false']",
+      "default": "true"
+    },
+    "downloadHidden": {
+      "type": ["string"],
+      "enum": ["true", "false"],
+      "title": "Download Hidden Files",
+      "description": "Whether or not to add hidden files to the archive when downloading; one of ['true', 'false']",
+      "default": "false"
     }
   },
   "additionalProperties": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ function downloadArchiveRequest(
 
   fullurl.searchParams.append("archiveToken", token(20));
   fullurl.searchParams.append("archiveFormat", archiveFormat);
+  fullurl.searchParams.append("followSymlinks", followSymlinks);
+  fullurl.searchParams.append("downloadHidden", downloadHidden);
 
   const xsrfTokenMatch = document.cookie.match("\\b_xsrf=([^;]*)\\b");
   if (xsrfTokenMatch) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,9 @@ namespace CommandIDs {
 
 function downloadArchiveRequest(
   path: string,
-  archiveFormat: ArchiveFormat
+  archiveFormat: ArchiveFormat,
+  followSymlinks: string,
+  downloadHidden: string
 ): Promise<void> {
   const settings = ServerConnection.makeSettings();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,8 @@ const extension: JupyterFrontEndPlugin<void> = {
       ".tar.xz"
     ];
     let archiveFormat: ArchiveFormat; // Default value read from settings
+    let followSymlinks: string; // Default value read from settings
+    let downloadHidden: string; // Default value read from settings
 
     // matches anywhere on filebrowser
     const selectorContent = ".jp-DirListing-content";
@@ -226,10 +228,14 @@ const extension: JupyterFrontEndPlugin<void> = {
         settings.changed.connect(settings => {
           const newFormat = settings.get("format").composite as ArchiveFormat;
           updateFormat(newFormat, archiveFormat);
+          followSymlinks = settings.get("followSymlinks").composite as string;
+          downloadHidden = settings.get("downloadHidden").composite as string;
         });
 
         const newFormat = settings.get("format").composite as ArchiveFormat;
         updateFormat(newFormat, archiveFormat);
+        followSymlinks = settings.get("followSymlinks").composite as string;
+        downloadHidden = settings.get("downloadHidden").composite as string;
       })
       .catch(reason => {
         console.error(reason);
@@ -251,7 +257,9 @@ const extension: JupyterFrontEndPlugin<void> = {
                 item.path,
                 allowedArchiveExtensions.indexOf("." + format) >= 0
                   ? format
-                  : archiveFormat
+                  : archiveFormat,
+              followSymlinks,
+              downloadHidden
               );
             }
           });
@@ -313,7 +321,9 @@ const extension: JupyterFrontEndPlugin<void> = {
             widget.model.path,
             allowedArchiveExtensions.indexOf("." + format) >= 0
               ? format
-              : archiveFormat
+              : archiveFormat,
+            followSymlinks,
+            downloadHidden
           );
         }
       },


### PR DESCRIPTION
This pull request adds two things. First, it makes the archive download process follow symlinks. I user symlinks to give the users of my JupyterHub deployment shared folders, and I want them to easily be able to extract all symlinked folders as well. This is the default behavior of using the `zip` command line utility, so I think it should also be the default behavior for this extension (though I'm not sure about other compression utilities).

The second behavior is more controversial. I exclude hidden directories. I personally think this is improved behavior because I have students use nbgitpuller to pull down content. When they download that folder to their own computer, they don't need the git folders. However, I'm not sure that this should be the default behavior for all possible use cases.

Ideally, I think both of these behaviors should be a setting with the default behavior being follow symlinks and download hidden files and folders. However, while I understand the Python code well, I have no experience with javascript (typescript?), and I can't figure out how to add the settings. If someone could work with me to add the settings component (or give me some directions), I think that would make this pull request make the most sense.

If I had boolean variables `follow_symlinks` and `download_hidden` (or similar), my code could very easily be updated in order to respect those settings.